### PR TITLE
Update style.css

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -29,7 +29,7 @@ body {
 
 #titlebar {
   display: block;
-  position:relative;
+  position: relative;
   height: 24px;
   font-weight: 600;
   width: 100%;
@@ -47,7 +47,7 @@ body {
 
 #titlebar {
   padding: 4px;
-  position:relative;
+  position: relative;
 }
 
 #titlebar #drag-region {

--- a/src/style.css
+++ b/src/style.css
@@ -29,25 +29,25 @@ body {
 
 #titlebar {
   display: block;
-  position: fixed;
+  position:relative;
   height: 24px;
   font-weight: 600;
-  width: calc(100% - 2px);
+  width: 100%;
 }
 
 .maximized #titlebar {
   width: 100%;
   padding: 0;
-}
+} 
 
 #main {
   height: calc(100% - 24px);
-  margin-top: 24px;
   overflow-y: auto;
 }
 
 #titlebar {
   padding: 4px;
+  position:relative;
 }
 
 #titlebar #drag-region {

--- a/src/style.css
+++ b/src/style.css
@@ -38,7 +38,7 @@ body {
 .maximized #titlebar {
   width: 100%;
   padding: 0;
-} 
+}
 
 #main {
   height: calc(100% - 24px);


### PR DESCRIPTION
fixed the title bar position
before: ![image](https://user-images.githubusercontent.com/62745638/163595871-36bf2dcc-7184-4208-9731-a94e3a0d1447.png)
Tested on ubuntu-20.04.4, Windows 10, Windows 11